### PR TITLE
support v1 location dialog plugin

### DIFF
--- a/autoexec.json
+++ b/autoexec.json
@@ -1,3 +1,4 @@
 {
-  "load": ["https://formit3d.github.io/FormItExamplePlugins/PluginManagerPlugin", "https://formit3d.github.io/FormItWorkflowPlugins/SetLocationDialog"]
+  "load": ["https://formit3d.github.io/FormItExamplePlugins/PluginManagerPlugin", "https://formit3d.github.io/FormItWorkflowPlugins/SetLocationDialog"],
+  "v1":  ["https://formit3d.github.io/FormItExamplePlugins/PluginManagerPlugin", "https://formit3d.github.io/FormItWorkflowPlugins/SetLocation/v1"]
 }


### PR DESCRIPTION
Poor mans versioning. Needed so we can test updated plugins before releasing them to the wild.