### PR TITLE
Fix DialogFromToolbar create block button

### DIFF
--- a/DialogFromToolbar/manifest.json
+++ b/DialogFromToolbar/manifest.json
@@ -2,6 +2,10 @@
     "PluginName": "Dialog From Toolbar UI",
     "PluginDescription": "Creates a toolbar UI with a button that launches an HTML page in a dialog.",
     "PluginType": "Toolbar",
-    "Scripts": [ "PLUGINLOCATION/dialogfromtoolbar.js", "PLUGINLOCATION/../HelloBlock/block.js" ],
+    "Scripts": [
+        "PLUGINLOCATION/dialogfromtoolbar.js",
+        "PLUGINLOCATION/../HelloBlock/block.js",
+        "PLUGINLOCATION/../SharedPluginFiles/PluginUtils.js"
+    ],
     "ToolbarURL": "PLUGINLOCATION/toolbar.json"
 }


### PR DESCRIPTION
When we want to create a block from the dialog toolbar there is a bug ` FormIt.PluginUtils` is undefined. 
I add the missing script in the manifest to fix the button